### PR TITLE
pdftk

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,28 +1,31 @@
-FROM ubuntu:bionic
-
-RUN apt-get update && apt-get install gnupg software-properties-common -y && apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0 \
-    && apt-add-repository https://cli.github.com/packages
-
+FROM ubuntu
+  
 RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime \
     && echo "Etc/UTC" > /etc/timezone \
     && apt-get update \
-    && apt-get upgrade -y \
-    && apt-get install bc texlive-full make gh python3.7 python3-pip git texlive-latex-extra texlive-fonts-recommended xzdec -y \
+    && apt-get upgrade -y 
+
+RUN apt-get install gnupg software-properties-common -y \
+    && apt-get install bc make python3 python3-pip git -y \
     && python3 -m pip install latex-dirtree-gen 
 
-RUN apt-get install -y openjdk-11-jdk
+RUN apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-extra texlive-latex-extra -y 
 
-RUN apt-get install -y wget unzip \
-    && wget https://services.gradle.org/distributions/gradle-7.3.2-bin.zip -P /tmp \ 
-    && unzip -d /opt/gradle /tmp/gradle-7.3.2-bin.zip \ 
-    && ln -s /opt/gradle/gradle-7.3.2 /opt/gradle/latest
+RUN apt-get install -y pdftk
 
-ENV GRADLE_HOME=/opt/gradle/latest
-ENV PATH=${GRADLE_HOME}/bin:${PATH}
+#RUN apt-get install -y openjdk-11-jdk
 
-RUN git clone https://gitlab.com/pdftk-java/pdftk \
-    && cd pdftk \
-    && gradle shadowJar \
-    && alias pdftk='java -jar /pdftk/build/libs/pdftk-all.jar'
+#RUN apt-get install -y wget unzip \
+#    && wget https://services.gradle.org/distributions/gradle-7.4.2-bin.zip -P /tmp \ 
+#    && unzip -d /opt/gradle /tmp/gradle-7.4.2-bin.zip \ 
+#    && ln -s /opt/gradle/gradle-7.4.2 /opt/gradle/latest
+
+#ENV GRADLE_HOME=/opt/gradle/latest
+#ENV PATH=${GRADLE_HOME}/bin:${PATH}
+
+#RUN git clone https://gitlab.com/pdftk-java/pdftk \
+#    && cd pdftk \
+#    && gradle shadowJar --no-daemon --no-watch-fs \
+#    && alias pdftk='java -jar /pdftk/build/libs/pdftk-all.jar'
 
 ENTRYPOINT [ "/bin/sh" ]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -13,19 +13,4 @@ RUN apt-get install texlive-latex-base texlive-fonts-recommended texlive-fonts-e
 
 RUN apt-get install -y pdftk
 
-#RUN apt-get install -y openjdk-11-jdk
-
-#RUN apt-get install -y wget unzip \
-#    && wget https://services.gradle.org/distributions/gradle-7.4.2-bin.zip -P /tmp \ 
-#    && unzip -d /opt/gradle /tmp/gradle-7.4.2-bin.zip \ 
-#    && ln -s /opt/gradle/gradle-7.4.2 /opt/gradle/latest
-
-#ENV GRADLE_HOME=/opt/gradle/latest
-#ENV PATH=${GRADLE_HOME}/bin:${PATH}
-
-#RUN git clone https://gitlab.com/pdftk-java/pdftk \
-#    && cd pdftk \
-#    && gradle shadowJar --no-daemon --no-watch-fs \
-#    && alias pdftk='java -jar /pdftk/build/libs/pdftk-all.jar'
-
 ENTRYPOINT [ "/bin/sh" ]

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -8,7 +8,21 @@ RUN ln -snf /usr/share/zoneinfo/Etc/UTC /etc/localtime \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get install bc texlive-full make gh python3.7 python3-pip git texlive-latex-extra texlive-fonts-recommended xzdec -y \
-    && python3 -m pip install latex-dirtree-gen \
-    && rm -rf /var/lib/apt/lists/*
+    && python3 -m pip install latex-dirtree-gen 
+
+RUN apt-get install -y openjdk-11-jdk
+
+RUN apt-get install -y wget unzip \
+    && wget https://services.gradle.org/distributions/gradle-7.3.2-bin.zip -P /tmp \ 
+    && unzip -d /opt/gradle /tmp/gradle-7.3.2-bin.zip \ 
+    && ln -s /opt/gradle/gradle-7.3.2 /opt/gradle/latest
+
+ENV GRADLE_HOME=/opt/gradle/latest
+ENV PATH=${GRADLE_HOME}/bin:${PATH}
+
+RUN git clone https://gitlab.com/pdftk-java/pdftk \
+    && cd pdftk \
+    && gradle shadowJar \
+    && alias pdftk='java -jar /pdftk/build/libs/pdftk-all.jar'
 
 ENTRYPOINT [ "/bin/sh" ]


### PR DESCRIPTION
This turned into a lot. We upgraded from `ubuntu:bionic` to `ubuntu:latest`. We upgraded the version of `python`. We removed custom `apt-get` configuration for installing `gh`. We added `pdftk`. We changed the way `\LaTeX` is installed. 